### PR TITLE
Fix launch deprecation

### DIFF
--- a/App/AppDelegate.swift
+++ b/App/AppDelegate.swift
@@ -11,7 +11,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate {}
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-	var window: UIWindow?
+    var window: UIWindow?
 }
 
 class ViewController: UIViewController {}

--- a/AppUITests/AppUITests.swift
+++ b/AppUITests/AppUITests.swift
@@ -14,8 +14,8 @@ class AppUITests: XCTestCase {
     }
 
     func testLaunchPerformance() throws {
-		measure(metrics: [XCTApplicationLaunchMetric()]) {
-			XCUIApplication().launch()
-		}
+        measure(metrics: [XCTApplicationLaunchMetric()]) {
+            XCUIApplication().launch()
+        }
     }
 }

--- a/AppUITests/AppUITestsLaunchTests.swift
+++ b/AppUITests/AppUITestsLaunchTests.swift
@@ -16,6 +16,6 @@ class AppUITestsLaunchTests: XCTestCase {
         attachment.name = "Launch Screen"
         attachment.lifetime = .keepAlways
 
-		add(attachment)
+        add(attachment)
     }
 }

--- a/PipeWrench/PipeWrench/Constants.swift
+++ b/PipeWrench/PipeWrench/Constants.swift
@@ -10,67 +10,67 @@ import Foundation
 @objc @objcMembers
 public final class PipeWrenchConstants: NSObject {
 
-	// MARK: - Enable / Disable
+    // MARK: - Enable / Disable
 
-	///
-	/// Environment variable to set if Pipe Wrench should be used to track leaks.
-	///
-	/// If not set, Pipe Wrench will not run, even when linked into a test target.
-	///
-	/// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
-	/// Evaluated with truthiness as defined by NSNumber https://developer.apple.com/documentation/foundation/nsnumber/1410865-boolvalue
-	public static let Enabled = "EnablePipeWrench"
+    ///
+    /// Environment variable to set if Pipe Wrench should be used to track leaks.
+    ///
+    /// If not set, Pipe Wrench will not run, even when linked into a test target.
+    ///
+    /// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
+    /// Evaluated with truthiness as defined by NSNumber https://developer.apple.com/documentation/foundation/nsnumber/1410865-boolvalue
+    public static let Enabled = "EnablePipeWrench"
 
-	// MARK: - Memgraph Management
+    // MARK: - Memgraph Management
 
-	///
-	/// Environment variable to set for memgraph storage.
-	///
-	/// This value must be a `String` that represents a path on disk.
-	/// If non-nil, Pipe Wrench will attempt to save files to this location.
-	/// If this variable is not set, Pipe Wrench will write to a temporary directory.
-	///
-	/// If the directory does not exist, Pipe Wrench will not attempt to create it, and will throw a `PipeWrenchDirectoryError.requestedMemgraphPathDoesNotExist` error
-	/// If an item exists at the requested path but it is not a directory, Pipe Wrench will throw a `PipeWrenchDirectoryError.requestedMemgraphPathIsNotADirectory` error
-	/// If the directory is not readable, Pipe Wrench will throw a `PipeWrenchDirectoryError.requestedMemgraphPathIsNotReadable` error
-	/// If the directory is not writable, Pipe Wrench will throw a `PipeWrenchDirectoryError.requestedMemgraphPathIsNotWritable` error
-	public static let MemgraphRootDirectory = "MemgraphRootDirectory"
+    ///
+    /// Environment variable to set for memgraph storage.
+    ///
+    /// This value must be a `String` that represents a path on disk.
+    /// If non-nil, Pipe Wrench will attempt to save files to this location.
+    /// If this variable is not set, Pipe Wrench will write to a temporary directory.
+    ///
+    /// If the directory does not exist, Pipe Wrench will not attempt to create it, and will throw a `PipeWrenchDirectoryError.requestedMemgraphPathDoesNotExist` error
+    /// If an item exists at the requested path but it is not a directory, Pipe Wrench will throw a `PipeWrenchDirectoryError.requestedMemgraphPathIsNotADirectory` error
+    /// If the directory is not readable, Pipe Wrench will throw a `PipeWrenchDirectoryError.requestedMemgraphPathIsNotReadable` error
+    /// If the directory is not writable, Pipe Wrench will throw a `PipeWrenchDirectoryError.requestedMemgraphPathIsNotWritable` error
+    public static let MemgraphRootDirectory = "MemgraphRootDirectory"
 
-	///
-	/// Environment variable to control whether PipeWrench will make a directory for saving files or not.
-	///
-	/// By default, PipeWrench will not create directories if they do not exist on disk.
-	///
-	/// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
-	public static let CreateMemgraphRootDirectory = "CreateMemgraphRootDirectory"
+    ///
+    /// Environment variable to control whether PipeWrench will make a directory for saving files or not.
+    ///
+    /// By default, PipeWrench will not create directories if they do not exist on disk.
+    ///
+    /// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
+    public static let CreateMemgraphRootDirectory = "CreateMemgraphRootDirectory"
 
-	///
-	/// Environment variable to set if Pipe Wrench should remove memgraph files when tests complete.
-	///
-	/// If not set, Pipe Wrench will preserve memgraph files when tests end.
-	///
-	/// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
-	public static let EraseMemgraphAfterTestCompletion = "EraseMemgraphAfterTestCompletion"
+    ///
+    /// Environment variable to set if Pipe Wrench should remove memgraph files when tests complete.
+    ///
+    /// If not set, Pipe Wrench will preserve memgraph files when tests end.
+    ///
+    /// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
+    public static let EraseMemgraphAfterTestCompletion = "EraseMemgraphAfterTestCompletion"
 
-	// MARK: - Logging
+    // MARK: - Logging
 
-	///
-	/// Environment variable to set if Pipe Wrench should remove memgraph files when tests complete.
-	///
-	/// If not set, Pipe Wrench will log to console.
-	///
-	/// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
-	public static let ConsoleLoggingEnabled = "ConsoleLoggingEnabled"
+    ///
+    /// Environment variable to set if Pipe Wrench should remove memgraph files when tests complete.
+    ///
+    /// If not set, Pipe Wrench will log to console.
+    ///
+    /// This value may be a `Boolean` (YES/NO, true/false), a `Number` (0/1) or a `String` of the preceeding values.
+    public static let ConsoleLoggingEnabled = "ConsoleLoggingEnabled"
 
-	///
-	/// Environment variable to set for memgraph storage.
-	///
-	/// This value must be a `String` that represents a path on disk.
-	/// If non-nil, Pipe Wrench will attempt to save files to this location.
-	/// If this variable is not set, Pipe Wrench will write to a temporary directory.
-	///
-	/// If the file already exists, Pipe Wrench will not attempt to append or overwrite, and will throw a `PipeWrenchDiskError.requestedPathExists` error
-	/// If the path is not readable, Pipe Wrench will throw a `PipeWrenchDiskError.requestedPathIsNotReadable` error
-	/// If the path is not writable, Pipe Wrench will throw a `PipeWrenchDiskError.requestedPathIsNotWritable` error
-	public static let DiskLoggingPath = "DiskLoggingPath"
+    ///
+    /// Environment variable to set for memgraph storage.
+    ///
+    /// This value must be a `String` that represents a path on disk.
+    /// If non-nil, Pipe Wrench will attempt to save files to this location.
+    /// If this variable is not set, Pipe Wrench will write to a temporary directory.
+    ///
+    /// If the file already exists, Pipe Wrench will not attempt to append or overwrite, and will throw a `PipeWrenchDiskError.requestedPathExists` error
+    /// If the path is not readable, Pipe Wrench will throw a `PipeWrenchDiskError.requestedPathIsNotReadable` error
+    /// If the path is not writable, Pipe Wrench will throw a `PipeWrenchDiskError.requestedPathIsNotWritable` error
+    public static let DiskLoggingPath = "DiskLoggingPath"
 }

--- a/PipeWrench/PipeWrench/Errors.swift
+++ b/PipeWrench/PipeWrench/Errors.swift
@@ -6,10 +6,10 @@
 //
 
 public enum PipeWrenchDiskError: Error {
-	case requestedPathExists
-	case requestedPathCouldNotBeCreated
-	case requestedPathDoesNotExist
-	case requestedPathIsNotADirectory
-	case requestedPathIsNotReadable
-	case requestedPathIsNotWritable
+    case requestedPathExists
+    case requestedPathCouldNotBeCreated
+    case requestedPathDoesNotExist
+    case requestedPathIsNotADirectory
+    case requestedPathIsNotReadable
+    case requestedPathIsNotWritable
 }

--- a/PipeWrench/PipeWrench/Logging.swift
+++ b/PipeWrench/PipeWrench/Logging.swift
@@ -11,71 +11,71 @@ import Foundation
 
 @objc(PWLogEgress)
 public protocol LogEgress {
-	func log(_ message: String)
+    func log(_ message: String)
 }
 
 @objc(PWLogIngest)
 public final class LogIngest: NSObject, LogEgress {
-	fileprivate var egressTargets = [LogEgress]()
+    fileprivate var egressTargets = [LogEgress]()
 
-	public func add(egressTarget: any LogEgress) {
-		egressTargets.append(egressTarget)
-	}
+    public func add(egressTarget: any LogEgress) {
+        egressTargets.append(egressTarget)
+    }
 
-	public func removeAll() {
-		egressTargets.removeAll()
-	}
+    public func removeAll() {
+        egressTargets.removeAll()
+    }
 
-	public func log(_ message: String) {
-		for target in egressTargets {
-			target.log(message)
-		}
-	}
+    public func log(_ message: String) {
+        for target in egressTargets {
+            target.log(message)
+        }
+    }
 }
 
 public final class ConsoleLogger: LogEgress {
-	public func log(_ message: String) {
-		print(message)
-	}
+    public func log(_ message: String) {
+        print(message)
+    }
 }
 
 public final class FileLogger: LogEgress {
-	let handle: FileHandle
+    let handle: FileHandle
 
-	init(path: String) throws {
-		try validatePathForLoggingStorage(path)
-		handle = FileHandle(forWritingAtPath: path)!
-		try handle.seekToEnd()
-	}
+    init(path: String) throws {
+        try validatePathForLoggingStorage(path)
+        handle = FileHandle(forWritingAtPath: path)!
+        try handle.seekToEnd()
+    }
 
-	deinit {
-		try? handle.close()
-	}
+    deinit {
+        try? handle.close()
+    }
 
-	public func log(_ message: String) {
-		try? handle.write(contentsOf: (message + "\n").data(using: .utf8)!)
-	}
+    public func log(_ message: String) {
+        try? handle.write(contentsOf: (message + "\n").data(using: .utf8)!)
+    }
 }
 
 // MARK: - Configuration
 
 internal extension PipeWrench {
-	func addLoggers() throws {
-		let consoleLoggingRequested = ProcessInfo.processInfo.environment[PipeWrenchConstants.ConsoleLoggingEnabled] ?? "true"
-		let consoleLoggingEnabled = (consoleLoggingRequested as NSString).boolValue
+    func addLoggers() throws {
+        let consoleLoggingRequested = ProcessInfo.processInfo.environment[PipeWrenchConstants.ConsoleLoggingEnabled] ?? "true"
+        let consoleLoggingEnabled = (consoleLoggingRequested as NSString).boolValue
 
-		if consoleLoggingEnabled {
-			logger.add(egressTarget: ConsoleLogger())
-		}
+        if consoleLoggingEnabled {
+            logger.add(egressTarget: ConsoleLogger())
+        }
 
-		let tentativePath = ProcessInfo.processInfo.environment[PipeWrenchConstants.DiskLoggingPath]
-		if let tentativePath = tentativePath {
-			let fileLogger = try FileLogger(path: tentativePath)
-			logger.add(egressTarget: fileLogger)
-		}
-	}
+        let tentativePath = ProcessInfo.processInfo.environment[PipeWrenchConstants.DiskLoggingPath]
+        if let tentativePath = tentativePath {
+            let fileLogger = try FileLogger(path: tentativePath)
+            logger.add(egressTarget: fileLogger)
+        }
+    }
 
-	func removeLoggers() {
-		logger.removeAll()
-	}
+    func removeLoggers() {
+        logger.removeAll()
+    }
 }

--- a/PipeWrench/PipeWrench/PathUtilities.swift
+++ b/PipeWrench/PipeWrench/PathUtilities.swift
@@ -8,48 +8,48 @@
 import Foundation
 
 internal func validatePathForMemgraphStorage(_ path: String) throws {
-	let fileManager = FileManager()
-
-	var isDirectory: ObjCBool = false
-	if !fileManager.fileExists(atPath: path, isDirectory: &isDirectory) {
-		let createIfDirectoryDoesNotExistEnvironment = ProcessInfo.processInfo.environment[PipeWrenchConstants.CreateMemgraphRootDirectory] ?? "false"
-		let createIfDirectoryDoesNotExistValue = (createIfDirectoryDoesNotExistEnvironment as NSString).boolValue
-		if !createIfDirectoryDoesNotExistValue {
-			throw PipeWrenchDiskError.requestedPathDoesNotExist
-		}
-
-		try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
-
-		if !fileManager.fileExists(atPath: path, isDirectory: &isDirectory) {
-			throw PipeWrenchDiskError.requestedPathCouldNotBeCreated
-		}
-	}
-
-	if !isDirectory.boolValue {
-		throw PipeWrenchDiskError.requestedPathIsNotADirectory
-	}
-
-	if !fileManager.isReadableFile(atPath: path) {
-		throw PipeWrenchDiskError.requestedPathIsNotReadable
-	}
-
-	if !fileManager.isWritableFile(atPath: path) {
-		throw PipeWrenchDiskError.requestedPathIsNotWritable
-	}
+    let fileManager = FileManager()
+    
+    var isDirectory: ObjCBool = false
+    if !fileManager.fileExists(atPath: path, isDirectory: &isDirectory) {
+        let createIfDirectoryDoesNotExistEnvironment = ProcessInfo.processInfo.environment[PipeWrenchConstants.CreateMemgraphRootDirectory] ?? "false"
+        let createIfDirectoryDoesNotExistValue = (createIfDirectoryDoesNotExistEnvironment as NSString).boolValue
+        if !createIfDirectoryDoesNotExistValue {
+            throw PipeWrenchDiskError.requestedPathDoesNotExist
+        }
+        
+        try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true)
+        
+        if !fileManager.fileExists(atPath: path, isDirectory: &isDirectory) {
+            throw PipeWrenchDiskError.requestedPathCouldNotBeCreated
+        }
+    }
+    
+    if !isDirectory.boolValue {
+        throw PipeWrenchDiskError.requestedPathIsNotADirectory
+    }
+    
+    if !fileManager.isReadableFile(atPath: path) {
+        throw PipeWrenchDiskError.requestedPathIsNotReadable
+    }
+    
+    if !fileManager.isWritableFile(atPath: path) {
+        throw PipeWrenchDiskError.requestedPathIsNotWritable
+    }
 }
 
 internal func validatePathForLoggingStorage(_ path: String) throws {
-	let fileManager = FileManager()
-
-	if fileManager.fileExists(atPath: path, isDirectory: nil) {
-		throw PipeWrenchDiskError.requestedPathExists
-	}
-
-	if !fileManager.isReadableFile(atPath: path) {
-		throw PipeWrenchDiskError.requestedPathIsNotReadable
-	}
-
-	if !fileManager.isReadableFile(atPath: path) {
-		throw PipeWrenchDiskError.requestedPathIsNotWritable
-	}
+    let fileManager = FileManager()
+    
+    if fileManager.fileExists(atPath: path, isDirectory: nil) {
+        throw PipeWrenchDiskError.requestedPathExists
+    }
+    
+    if !fileManager.isReadableFile(atPath: path) {
+        throw PipeWrenchDiskError.requestedPathIsNotReadable
+    }
+    
+    if !fileManager.isReadableFile(atPath: path) {
+        throw PipeWrenchDiskError.requestedPathIsNotWritable
+    }
 }

--- a/PipeWrench/PipeWrench/PipeWrench.swift
+++ b/PipeWrench/PipeWrench/PipeWrench.swift
@@ -11,119 +11,119 @@ import XCTest
 
 @objc(PWPipeWrench)
 public final class PipeWrench: NSObject {
-	private var isRunning = false
+    private var isRunning = false
 
-	private var memgraphDirectory: String!
-	private var memgraphNames = Set<String>()
+    private var memgraphDirectory: String!
+    private var memgraphNames = Set<String>()
 
-	internal var logger: LogIngest
+    internal var logger: LogIngest
 
-	@objc
-	public init(logger: LogIngest) {
-		self.logger = logger
-	}
+    @objc
+    public init(logger: LogIngest) {
+        self.logger = logger
+    }
 
-	@objc public func start() throws {
-		if !isRunning {
-			try addLoggers()
+    @objc public func start() throws {
+        if !isRunning {
+            try addLoggers()
 
-			let path = ProcessInfo.processInfo.environment[PipeWrenchConstants.MemgraphRootDirectory] ?? "/tmp/PipeWrench/\(UUID().uuidString)/".replacingOccurrences(of: "-", with: "")
-			try validatePathForMemgraphStorage(path)
-			logger.log("using memgraph root: \(path)")
-			memgraphDirectory = path
+            let path = ProcessInfo.processInfo.environment[PipeWrenchConstants.MemgraphRootDirectory] ?? "/tmp/PipeWrench/\(UUID().uuidString)/".replacingOccurrences(of: "-", with: "")
+            try validatePathForMemgraphStorage(path)
+            logger.log("using memgraph root: \(path)")
+            memgraphDirectory = path
 
-			isRunning = true
+            isRunning = true
 
-			XCTestObservationCenter.shared.addTestObserver(self)
-		}
-	}
+            XCTestObservationCenter.shared.addTestObserver(self)
+        }
+    }
 
-	@objc public func stop() {
-		if isRunning {
-			XCTestObservationCenter.shared.removeTestObserver(self)
-			isRunning = false
+    @objc public func stop() {
+        if isRunning {
+            XCTestObservationCenter.shared.removeTestObserver(self)
+            isRunning = false
 
-			removeLoggers()
-		}
-	}
+            removeLoggers()
+        }
+    }
 }
 
 extension PipeWrench: XCTestObservation {
-	public func testCase(_ testCase: XCTestCase, didRecord expectedFailure: XCTExpectedFailure) {
-		let location = expectedFailure.issue.sourceCodeContext.location!
-		let name = "\(location.fileURL.lastPathComponent):\(location.lineNumber)"
-		saveMemgraphToDisk(with: name)
+    public func testCase(_ testCase: XCTestCase, didRecord expectedFailure: XCTExpectedFailure) {
+        let location = expectedFailure.issue.sourceCodeContext.location!
+        let name = "\(location.fileURL.lastPathComponent):\(location.lineNumber)"
+        saveMemgraphToDisk(with: name)
 
-		if hasLeaks(fromMemgraph: name) {
-			logger.log("test  completed: has memory leak")
+        if hasLeaks(fromMemgraph: name) {
+            logger.log("test  completed: has memory leak")
 
-			printLeaks(fromMemgraph: name)
-		}
-	}
+            printLeaks(fromMemgraph: name)
+        }
+    }
 
-	public func testBundleDidFinish(_ testBundle: Bundle) {
-		let name = testBundle.bundleURL.lastPathComponent
-		saveMemgraphToDisk(with: name)
+    public func testBundleDidFinish(_ testBundle: Bundle) {
+        let name = testBundle.bundleURL.lastPathComponent
+        saveMemgraphToDisk(with: name)
 
-		if hasLeaks(fromMemgraph: name) {
-			logger.log("test bundle completed: has memory leak")
+        if hasLeaks(fromMemgraph: name) {
+            logger.log("test bundle completed: has memory leak")
 
-			printLeaks(fromMemgraph: name)
-			findAddressesForLeaks(fromMemgraph: name)
-		}
-	}
+            printLeaks(fromMemgraph: name)
+            findAddressesForLeaks(fromMemgraph: name)
+        }
+    }
 
-	public func testCaseDidFinish(_ testCase: XCTestCase) {
-		let eraseOnCompletionEnvironment = ProcessInfo.processInfo.environment[PipeWrenchConstants.EraseMemgraphAfterTestCompletion] ?? "false"
-		let eraseOnCompletionValue = (eraseOnCompletionEnvironment as NSString).boolValue
-		guard eraseOnCompletionValue else {
-			return
-		}
+    public func testCaseDidFinish(_ testCase: XCTestCase) {
+        let eraseOnCompletionEnvironment = ProcessInfo.processInfo.environment[PipeWrenchConstants.EraseMemgraphAfterTestCompletion] ?? "false"
+        let eraseOnCompletionValue = (eraseOnCompletionEnvironment as NSString).boolValue
+        guard eraseOnCompletionValue else {
+            return
+        }
 
-		for name in memgraphNames {
-			let fileManager = FileManager()
-			try? fileManager.removeItem(atPath: memgraphLocation(for: name))
-		}
-	}
+        for name in memgraphNames {
+            let fileManager = FileManager()
+            try? fileManager.removeItem(atPath: memgraphLocation(for: name))
+        }
+    }
 
-	// MARK: - Helper Methods
+    // MARK: - Helper Methods
 
-	private func printValueFromPipe(_ string: String) {
-		logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
-	}
+    private func printValueFromPipe(_ string: String) {
+        logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
+    }
 
-	private func read(from pipe: Pipe, named name: String, onRead: (String) -> Void) {
-		let fileHandle = pipe.fileHandleForReading
-		do {
-			if let data = try fileHandle.readToEnd(),
-			   let string = String(data: data, encoding: .utf8) {
-				onRead(string)
-			}
-		} catch {
-			logger.log("caught exception reading \(name): \(error)")
-		}
-	}
+    private func read(from pipe: Pipe, named name: String, onRead: (String) -> Void) {
+        let fileHandle = pipe.fileHandleForReading
+        do {
+            if let data = try fileHandle.readToEnd(),
+               let string = String(data: data, encoding: .utf8) {
+                onRead(string)
+            }
+        } catch {
+            logger.log("caught exception reading \(name): \(error)")
+        }
+    }
 
-	private func memgraphLocation(for name: String) -> String {
-		memgraphDirectory + "/\(name).memgraph"
-	}
+    private func memgraphLocation(for name: String) -> String {
+        memgraphDirectory + "/\(name).memgraph"
+    }
 
-	// MARK: - Methods That Do Things
+    // MARK: - Methods That Do Things
 
-	private func saveMemgraphToDisk(with name: String) {
-		memgraphNames.insert(name)
+    private func saveMemgraphToDisk(with name: String) {
+        memgraphNames.insert(name)
 
-		let task = NSTask()
-		task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
-		task.arguments = [
-			"\(getpid())",
-			"--outputGraph=\(memgraphLocation(for: name))"
-		]
+        let task = NSTask()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
+        task.arguments = [
+            "\(getpid())",
+            "--outputGraph=\(memgraphLocation(for: name))"
+        ]
 
-		let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
-		task.standardError = stderr
-		task.standardOutput = stdout
-		task.standardInput = stdin
+        let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
+        task.standardError = stderr
+        task.standardOutput = stdout
+        task.standardInput = stdin
 
         do {
             try task.launchAndReturnError()
@@ -131,24 +131,24 @@ extension PipeWrench: XCTestObservation {
             logger.log("saveMemgraphToDisk task.launch returns error \(error.localizedDescription)")
         }
 
-		task.waitUntilExit()
+        task.waitUntilExit()
 
-		read(from: stdout, named: "stdout", onRead: { string in
-			logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
-		})
-	}
+        read(from: stdout, named: "stdout", onRead: { string in
+            logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
+        })
+    }
 
-	private func hasLeaks(fromMemgraph name: String) -> Bool {
-		let task = NSTask()
-		task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
-		task.arguments = [
-			"\(memgraphLocation(for: name))"
-		]
+    private func hasLeaks(fromMemgraph name: String) -> Bool {
+        let task = NSTask()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
+        task.arguments = [
+            "\(memgraphLocation(for: name))"
+        ]
 
-		let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
-		task.standardError = stderr
-		task.standardOutput = stdout
-		task.standardInput = stdin
+        let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
+        task.standardError = stderr
+        task.standardOutput = stdout
+        task.standardInput = stdin
 
         do {
             try task.launchAndReturnError()
@@ -156,22 +156,22 @@ extension PipeWrench: XCTestObservation {
             logger.log("hasLeaks task.launch returns error \(error.localizedDescription)")
         }
 
-		task.waitUntilExit()
+        task.waitUntilExit()
 
-		return task.terminationStatus == 1
-	}
+        return task.terminationStatus == 1
+    }
 
-	private func printLeaks(fromMemgraph name: String) {
-		let task = NSTask()
-		task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
-		task.arguments = [
-			"\(memgraphLocation(for: name))"
-		]
+    private func printLeaks(fromMemgraph name: String) {
+        let task = NSTask()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
+        task.arguments = [
+            "\(memgraphLocation(for: name))"
+        ]
 
-		let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
-		task.standardError = stderr
-		task.standardOutput = stdout
-		task.standardInput = stdin
+        let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
+        task.standardError = stderr
+        task.standardOutput = stdout
+        task.standardInput = stdin
 
         do {
             try task.launchAndReturnError()
@@ -179,24 +179,24 @@ extension PipeWrench: XCTestObservation {
             logger.log("printLeaks task.launch returns error \(error.localizedDescription)")
         }
 
-		task.waitUntilExit()
+        task.waitUntilExit()
 
-		read(from: stdout, named: "stdout", onRead: { string in
-			logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
-		})
-	}
+        read(from: stdout, named: "stdout", onRead: { string in
+            logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
+        })
+    }
 
-	private func findAddressesForLeaks(fromMemgraph name: String) {
-		let task = NSTask()
-		task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
-		task.arguments = [
-			"\(memgraphLocation(for: name))"
-		]
+    private func findAddressesForLeaks(fromMemgraph name: String) {
+        let task = NSTask()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/leaks")
+        task.arguments = [
+            "\(memgraphLocation(for: name))"
+        ]
 
-		let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
-		task.standardError = stderr
-		task.standardOutput = stdout
-		task.standardInput = stdin
+        let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
+        task.standardError = stderr
+        task.standardOutput = stdout
+        task.standardInput = stdin
 
         do {
             try task.launchAndReturnError()
@@ -204,58 +204,58 @@ extension PipeWrench: XCTestObservation {
             logger.log("findAddressesForLeaks task.launch returns error \(error.localizedDescription)")
         }
 
-		task.waitUntilExit()
+        task.waitUntilExit()
 
-//		for addr in `leaks ~/Desktop/MemgraphTests.xctest.memgraph | grep LEAK | awk '{ print $6 }’`
-//		do
-//			heap --addresses=all ~/Desktop/MemgraphTests.xctest.memgraph | grep $leak
-//		done
-		read(from: stdout, named: "stdout", onRead: { string in
-			for line in string.components(separatedBy: "\n") {
-				if !line.contains("LEAK") {
-					continue
-				}
+        //		for addr in `leaks ~/Desktop/MemgraphTests.xctest.memgraph | grep LEAK | awk '{ print $6 }’`
+        //		do
+        //			heap --addresses=all ~/Desktop/MemgraphTests.xctest.memgraph | grep $leak
+        //		done
+        read(from: stdout, named: "stdout", onRead: { string in
+            for line in string.components(separatedBy: "\n") {
+                if !line.contains("LEAK") {
+                    continue
+                }
 
-				let regex = try? NSRegularExpression(pattern: "0x(\\d|\\w)*", options: [])
-				let range = NSRange(location: 0, length: (line as NSString).length )
-				regex?.enumerateMatches(in: line, options: [], range: range) { result, flags, stop in
-					if let result = result {
-						let result = (line as NSString).substring(with: result.range)
-						printClass(for: result, fromMemgraph: name)
-					}
-				}
-			}
-		})
-	}
+                let regex = try? NSRegularExpression(pattern: "0x(\\d|\\w)*", options: [])
+                let range = NSRange(location: 0, length: (line as NSString).length )
+                regex?.enumerateMatches(in: line, options: [], range: range) { result, flags, stop in
+                    if let result = result {
+                        let result = (line as NSString).substring(with: result.range)
+                        printClass(for: result, fromMemgraph: name)
+                    }
+                }
+            }
+        })
+    }
 
-	// heap --addresses=all ~/Desktop/MemgraphTests.xctest.memgraph | grep $leak
-	private func printClass(for address: String, fromMemgraph name: String) {
-		logger.log("heap for \(address) \(memgraphLocation(for: name))")
+    // heap --addresses=all ~/Desktop/MemgraphTests.xctest.memgraph | grep $leak
+    private func printClass(for address: String, fromMemgraph name: String) {
+        logger.log("heap for \(address) \(memgraphLocation(for: name))")
 
-		let task = NSTask()
-		task.executableURL = URL(fileURLWithPath: "/usr/bin/heap")
-		task.arguments = [
-			"--addresses=all",
-			"\(memgraphLocation(for: name))"
-		]
+        let task = NSTask()
+        task.executableURL = URL(fileURLWithPath: "/usr/bin/heap")
+        task.arguments = [
+            "--addresses=all",
+            "\(memgraphLocation(for: name))"
+        ]
 
-		let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
-		task.standardError = stderr
-		task.standardOutput = stdout
-		task.standardInput = stdin
+        let (stderr, stdout, stdin) = (Pipe(), Pipe(), Pipe())
+        task.standardError = stderr
+        task.standardOutput = stdout
+        task.standardInput = stdin
 
-		task.launch()
-		task.waitUntilExit()
+        task.launch()
+        task.waitUntilExit()
 
-		logger.log("addr \(address)")
-		read(from: stdin, named: "stdin", onRead: { string in
-			logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
-		})
-		read(from: stdout, named: "stdout", onRead: { string in
-			logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
-		})
-		read(from: stderr, named: "stderr", onRead: { string in
-			logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
-		})
-	}
+        logger.log("addr \(address)")
+        read(from: stdin, named: "stdin", onRead: { string in
+            logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
+        })
+        read(from: stdout, named: "stdout", onRead: { string in
+            logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
+        })
+        read(from: stderr, named: "stderr", onRead: { string in
+            logger.log(string.replacingOccurrences(of: "\\n", with: "\n"))
+        })
+    }
 }

--- a/PipeWrench/PipeWrench/PipeWrench.swift
+++ b/PipeWrench/PipeWrench/PipeWrench.swift
@@ -125,7 +125,12 @@ extension PipeWrench: XCTestObservation {
 		task.standardOutput = stdout
 		task.standardInput = stdin
 
-		task.launch()
+        do {
+            try task.launchAndReturnError()
+        } catch {
+            logger.log("saveMemgraphToDisk task.launch returns error \(error.localizedDescription)")
+        }
+
 		task.waitUntilExit()
 
 		read(from: stdout, named: "stdout", onRead: { string in
@@ -145,7 +150,12 @@ extension PipeWrench: XCTestObservation {
 		task.standardOutput = stdout
 		task.standardInput = stdin
 
-		task.launch()
+        do {
+            try task.launchAndReturnError()
+        } catch {
+            logger.log("hasLeaks task.launch returns error \(error.localizedDescription)")
+        }
+
 		task.waitUntilExit()
 
 		return task.terminationStatus == 1
@@ -163,7 +173,12 @@ extension PipeWrench: XCTestObservation {
 		task.standardOutput = stdout
 		task.standardInput = stdin
 
-		task.launch()
+        do {
+            try task.launchAndReturnError()
+        } catch {
+            logger.log("printLeaks task.launch returns error \(error.localizedDescription)")
+        }
+
 		task.waitUntilExit()
 
 		read(from: stdout, named: "stdout", onRead: { string in
@@ -183,7 +198,12 @@ extension PipeWrench: XCTestObservation {
 		task.standardOutput = stdout
 		task.standardInput = stdin
 
-		task.launch()
+        do {
+            try task.launchAndReturnError()
+        } catch {
+            logger.log("findAddressesForLeaks task.launch returns error \(error.localizedDescription)")
+        }
+
 		task.waitUntilExit()
 
 //		for addr in `leaks ~/Desktop/MemgraphTests.xctest.memgraph | grep LEAK | awk '{ print $6 }’`


### PR DESCRIPTION
- Per [Apple's doc](https://developer.apple.com/documentation/foundation/nstask/1414189-launch) `task.launch()` is deprecated so update to `task.launchAndReturnError()` instead
- Fix indentions